### PR TITLE
add defaultNamespace handler

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -22,11 +22,13 @@ type Engine interface {
 	// Learn prcoesses the given input template for resources to be monitored, adding each of those to the engine cache.
 	// Learn is additive:  it can be called multiple times with different inputs to amalgamate at complete set.
 	// This is useful when multiple templates will be used with the same rendering engine.
-	Learn(in io.Reader) error
+	// DefaultNamespace specifies a namespace to translate "" into, if desired.
+	Learn(in io.Reader, defaultNamespace string) error
 
 	// Render process the given input as a template, writing it to the provided output.
 	// Make sure Learn has already been called for the given template.
-	Render(out io.Writer, in io.Reader) error
+	// DefaultNamespace specifies a namespace to translate "" into, if desired.
+	Render(out io.Writer, in io.Reader, defaultNamespace string) error
 }
 
 // NewEngine returns a new rendering engine.

--- a/internal/engine/data.go
+++ b/internal/engine/data.go
@@ -17,8 +17,9 @@ import (
 var ErrNoNamespace = errors.New("namespace not monitored (did you call Learn()?)")
 
 type DataProvider struct {
-	learning bool
-	e        *Engine
+	defaultNamespace string
+	learning         bool
+	e                *Engine
 }
 
 func (p *DataProvider) getOrCreateNamespace(namespace string) *Namespace {
@@ -30,8 +31,17 @@ func (p *DataProvider) getOrCreateNamespace(namespace string) *Namespace {
 	return n
 }
 
+func (p *DataProvider) namespace(in string) string {
+	if in == "" {
+		return p.defaultNamespace
+	}
+
+	return in
+}
+
 // ConfigMap returns a kubernetes ConfigMap value
 func (p *DataProvider) ConfigMap(name, namespace, key string) (string, error) {
+	namespace = p.namespace(namespace)
 
 	if p.learning {
 		n := p.getOrCreateNamespace(namespace)
@@ -59,6 +69,8 @@ func (p *DataProvider) ConfigMap(name, namespace, key string) (string, error) {
 
 // Secret returns a kubernetes Secret value
 func (p *DataProvider) Secret(name, namespace, key string) (out string, err error) {
+	namespace = p.namespace(namespace)
+
 	b64Data, err := p.SecretBinary(name, namespace, key)
 	if err != nil {
 		return "", err
@@ -76,6 +88,8 @@ func (p *DataProvider) Secret(name, namespace, key string) (out string, err erro
 
 // SecretBinary returns a kubernetes Secret binary value
 func (p *DataProvider) SecretBinary(name, namespace, key string) (out []byte, err error) {
+	namespace = p.namespace(namespace)
+
 	if p.learning {
 		n := p.getOrCreateNamespace(namespace)
 
@@ -107,6 +121,8 @@ func (p *DataProvider) Env(name string) string {
 
 // Service returns a kubernetes Service
 func (p *DataProvider) Service(name, namespace string) (s *v1.Service, err error) {
+	namespace = p.namespace(namespace)
+
 	if p.learning {
 		n := p.getOrCreateNamespace(namespace)
 
@@ -123,6 +139,8 @@ func (p *DataProvider) Service(name, namespace string) (s *v1.Service, err error
 
 // ServiceIP returns a kubernetes Service's ClusterIP
 func (p *DataProvider) ServiceIP(name, namespace string) (string, error) {
+	namespace = p.namespace(namespace)
+
 	service, err := p.Service(name, namespace)
 	if err != nil {
 		return "", nil
@@ -133,6 +151,8 @@ func (p *DataProvider) ServiceIP(name, namespace string) (string, error) {
 
 // Endpoints returns the Endpoints for the given Service
 func (p *DataProvider) Endpoints(name, namespace string) (ep *v1.Endpoints, err error) {
+	namespace = p.namespace(namespace)
+
 	if p.learning {
 		n := p.getOrCreateNamespace(namespace)
 
@@ -149,6 +169,8 @@ func (p *DataProvider) Endpoints(name, namespace string) (ep *v1.Endpoints, err 
 
 // EndpointIPs returns the set of IP addresses for the given Service's endpoints.
 func (p *DataProvider) EndpointIPs(name, namespace string) (out []string, err error) {
+	namespace = p.namespace(namespace)
+
 	eps, err := p.Endpoints(name, namespace)
 	if err != nil {
 		return nil, err

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -83,7 +83,7 @@ func (e *Engine) render(out io.Writer, in io.Reader, p *DataProvider) error {
 }
 
 // Learn processes the given input as a template, recording any discovered resources to the resource monitors.
-func (e *Engine) Learn(in io.Reader) error {
+func (e *Engine) Learn(in io.Reader, defaultNamespace string) error {
 	e.learnMutex.Lock()
 	defer e.learnMutex.Unlock()
 
@@ -93,18 +93,20 @@ func (e *Engine) Learn(in io.Reader) error {
 	}()
 
 	return e.render(io.Discard, in, &DataProvider{
+		defaultNamespace: defaultNamespace,
 		learning: true,
 		e:        e,
 	})
 }
 
 // Render processes the given input as a template, writing it to the provided output
-func (e *Engine) Render(out io.Writer, in io.Reader) error {
+func (e *Engine) Render(out io.Writer, in io.Reader, defaultNamespace string) error {
 
 	e.learnMutex.RLock()
 	defer e.learnMutex.RUnlock()
 
 	return e.render(out, in, &DataProvider{
+		defaultNamespace: defaultNamespace,
 		learning: false,
 		e:        e,
 	})


### PR DESCRIPTION
Allow specification of a `defaultNamespace`, which allows for transparent translation of template-based references to `""` to a given default namespace.

This makes it easier to reuse templates across namespaces.

Signed-off-by: Seán C McCord <ulexus@gmail.com>